### PR TITLE
Renamed create_ optional function to ensure_

### DIFF
--- a/src/BaseTypes.h
+++ b/src/BaseTypes.h
@@ -163,7 +163,7 @@
   * It creates the following class methods.
   *
   * - `NAME()` returns a std::optional<TYPE> containing the child or std::nullopt if none.
-  * - `create_NAME(args...) if the child does not exist, creates the child from the input constructor arguments. Otherwise returns the child.
+  * - `ensure_NAME(args...) if the child does not exist, creates the child from the input constructor arguments. Otherwise returns the child.
   * - `clear_NAME(args...) clears the child from JSON document.
   *
   * @param TYPE the type of the child object or array
@@ -172,7 +172,7 @@
  #define MNX_OPTIONAL_CHILD(TYPE, NAME) \
     [[nodiscard]] std::optional<TYPE> NAME() const { return getOptionalChild<TYPE>(#NAME); } \
     template<typename... Args> \
-    TYPE create_##NAME(Args&&... args) { \
+    TYPE ensure_##NAME(Args&&... args) { \
         if (auto child = getOptionalChild<TYPE>(#NAME)) return child.value(); \
         return setChild(#NAME, TYPE(*this, #NAME, std::forward<Args>(args)...)); \
     } \

--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -361,7 +361,7 @@ public:
     {
         // per the specification, either noteValue or the full-measure boolean *must* be supplied.
         if (noteValue) {
-            create_duration(noteValue.value());
+            ensure_duration(noteValue.value());
         } else {
             set_measure(true);
         }

--- a/tests/test_document.cpp
+++ b/tests/test_document.cpp
@@ -75,7 +75,7 @@ TEST(Document, MinimalFromScratch)
     mnx.set_version(MNX_VERSION + 1);
     EXPECT_EQ(doc.mnx().version(), MNX_VERSION + 1);
 
-    auto support = mnx.create_support();
+    auto support = mnx.ensure_support();
     support.set_useAccidentalDisplay(true);
 
     EXPECT_TRUE(support.useAccidentalDisplay()) << "mnx has a support instance";
@@ -93,7 +93,7 @@ TEST(Document, MinimalFromScratch)
     measures.append();
     EXPECT_TRUE(validation::schemaValidate(doc)) << "schema should validate after adding a measure to a part";
 
-    auto layouts = doc.create_layouts();
+    auto layouts = doc.ensure_layouts();
     layouts.append();
     auto layout = layouts[0];
     EXPECT_TRUE(validation::schemaValidate(doc)) << "schema should validate after adding a layout, even with no layout id";

--- a/tests/test_scores.cpp
+++ b/tests/test_scores.cpp
@@ -36,15 +36,15 @@ TEST(Scores, FromScratch)
     }
     EXPECT_EQ(doc.global().measures().size(), size_t(numBars));
 
-    auto scores = doc.create_scores();
+    auto scores = doc.ensure_scores();
 
     auto score = scores.append("Full Score");
-    auto pages = score.create_pages();
+    auto pages = score.ensure_pages();
     auto page = pages.append();
     auto system = page.systems().append(1);
     EXPECT_EQ(system.measure(), 1);
     EXPECT_EQ(page.systems().append(4).measure(), 4);
-    auto layoutChanges = system.create_layoutChanges();
+    auto layoutChanges = system.ensure_layoutChanges();
     auto layoutChange = layoutChanges.append("layout1", 2, FractionValue(3, 8));
     EXPECT_EQ(layoutChange.layout(), "layout1");
     EXPECT_EQ(layoutChange.location().measure(), 2);


### PR DESCRIPTION
MNX_OPTIONAL_CHILD now uses `ensure_##NAME` rather than `create_##NAME` to indicate that the child is created only if necessary.