### PR TITLE
Top-level document validation.

### DIFF
--- a/src/validation/SemanticValidate.cpp
+++ b/src/validation/SemanticValidate.cpp
@@ -630,5 +630,58 @@ SemanticValidationResult semanticValidate(const Document& document)
     return validator.result;
 }
 
+namespace {
+// allowed root-level items defined here
+constexpr std::array<std::string_view, 8> allowedItems = {
+    "global",
+    "layouts",
+    "mnx",
+    "parts",
+    "scores",
+    "_c",
+    "_x",
+    "id"
+};
+
+constexpr bool allowedItemsContains(std::string_view key)
+{
+    for (auto v : allowedItems) {
+        if (v == key) {
+            return true;
+        }
+    }
+    return false;
+}
+} // namespace
+
+bool hasValidDocumentRoot(const Document& document)
+{
+    // required items found here
+    bool foundGlobal = false;
+    bool foundParts = false;
+    bool foundMnx = false;
+
+    const auto root = document.root();
+    for (const auto& [key, value] : root->items()) {
+        if (!allowedItemsContains(key)) {
+            return false;
+        }
+        if (key == "global") {
+            foundGlobal = true;
+        }
+        if (key == "parts") {
+            foundParts = true;
+        }
+        if (key == "mnx") {
+            const auto mnx = root->at("mnx");
+            if (!mnx["version"].empty()) {
+                foundMnx = true;
+            }
+        }
+    }
+
+    return foundGlobal && foundParts && foundMnx;
+}
+
 } // namespace validation
 } // namespace mnx

--- a/src/validation/Validation.h
+++ b/src/validation/Validation.h
@@ -82,12 +82,18 @@ struct SemanticValidationResult : public ValidationResult
 /// @param document The mnx::Document to validate
 /// @param jsonSchema The JSON schema to validate against, or std::nullopt for the embedded schema
 /// @return validation result
-ValidationResult schemaValidate(const Document& document, const std::optional<std::string>& jsonSchema = std::nullopt);
+extern ValidationResult schemaValidate(const Document& document, const std::optional<std::string>& jsonSchema = std::nullopt);
 
 /// @brief Validates the semantics of the input MNX document
 /// @param document The document to validate
 /// @return validation result
-SemanticValidationResult semanticValidate(const Document& document);
+extern SemanticValidationResult semanticValidate(const Document& document);
+
+/// @brief Detects if the input JSON has a valid document root. This allows client code to permit a
+/// non-schema-conforming document to run anyway, perhaps with a warning to the user.
+/// @param document The document to check.
+/// @return True if the document root is a valid MNX document root.
+extern bool hasValidDocumentRoot(const Document& document);
 
 } // namespace validation
 } // namespace mnx

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(mnxdom_tests
     test_scores.cpp
     test_sequences.cpp
     test_ottavas.cpp
+    validation/test_document.cpp
     validation/test_examples.cpp
     validation/test_global.cpp
     validation/test_layouts.cpp

--- a/tests/data/inputs/validation/invalid_mnx.json
+++ b/tests/data/inputs/validation/invalid_mnx.json
@@ -1,0 +1,21 @@
+{
+  "mnx": {
+    "version": 1
+  },
+  "global": {
+    "key": "C major",
+    "time": 4
+  },
+  "parts": {
+    "P1": {
+      "name": 123,
+      "measures": {}
+    }
+  },
+  "scores": {
+    "score-1": {
+      "title": 123,
+      "parts": "not-an-array"
+    }
+  }
+}

--- a/tests/data/inputs/validation/unrelated_json.json
+++ b/tests/data/inputs/validation/unrelated_json.json
@@ -1,0 +1,14 @@
+{
+  "user": {
+    "id": 42,
+    "name": "Ada Boy",
+    "email": "ada@example.com",
+    "roles": ["admin", "editor"]
+  },
+  "preferences": {
+    "theme": "dark",
+    "notifications": true,
+    "language": "en-US"
+  },
+  "lastLogin": "2026-01-31T18:42:00Z"
+}

--- a/tests/validation/test_document.cpp
+++ b/tests/validation/test_document.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025, Robert Patterson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <string>
+#include <filesystem>
+#include <iterator>
+
+#include "gtest/gtest.h"
+#include "mnxdom.h"
+#include "test_utils.h"
+
+TEST(Document, UnrelatedJson)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath = getInputPath() / "validation" / "unrelated_json.json";
+    auto doc = mnx::Document::create(inputPath);
+    EXPECT_FALSE(mnx::validation::schemaValidate(doc));
+    EXPECT_FALSE(mnx::validation::hasValidDocumentRoot(doc));
+}
+
+TEST(Document, ValidTopLevelRoot)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath = getInputPath() / "validation" / "invalid_mnx.json";
+    auto doc = mnx::Document::create(inputPath);
+    EXPECT_FALSE(mnx::validation::schemaValidate(doc));
+    EXPECT_TRUE(mnx::validation::hasValidDocumentRoot(doc));
+}


### PR DESCRIPTION
- add `validation::hasValidDocumentRoot` for top-level validation only

This provides a level of flexibility with import validation, rather than just outright refusal to process.
