### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/validation/SemanticValidate.cpp
+++ b/src/validation/SemanticValidate.cpp
@@ -382,8 +382,8 @@ void SemanticValidator::validateBeams(const mnx::Array<mnx::part::Beam>& beams, 
         if (beam.direction().has_value() && beam.events().size() != 1) {
             addError("Beam specifies a hook direction but contains more than one event.", beam);
         }
-        if (auto beams = beam.beams()) {
-            validateBeams(beams.value(), depth + 1);
+        if (auto singleBeam = beam.beams()) {
+            validateBeams(singleBeam.value(), depth + 1);
         }
     }
 }


### PR DESCRIPTION
reg.: declaration of 'beams' hides function parameter (C4475)