### PR TITLE
Several changes helping distribute this software

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ project(mnxdom LANGUAGES CXX)
 
 include(FetchContent)
 
+# Options for using system libraries instead of fetching from the internet
+option(USE_SYSTEM_NLOHMANN_JSON "Use system-installed nlohmann_json instead of fetching" OFF)
+option(USE_SYSTEM_JSON_SCHEMA_VALIDATOR "Use system-installed nlohmann_json_schema_validator instead of fetching" OFF)
+# Set MNX_W3C_SOURCE to a directory path to use local mnx_w3c files instead of fetching
+set(MNX_W3C_SOURCE "" CACHE PATH "Path to local mnx_w3c repository (if empty, will fetch from GitHub)")
+
 option(BUILD_SHARED_LIBS "Build mnxdom as a shared library" OFF)
 
 # Set default build type to Release
@@ -46,30 +52,45 @@ add_library(mnxdom
 
 target_include_directories(mnxdom PUBLIC src)
 
-# Disable building tests for nlohmann_json
-set(JSON_BuildTests OFF CACHE BOOL "Do not build tests for nlohmann_json")
 # Define the version of nlohmann_json to use
-set(NLOHMANN_JSON_VERSION v3.12.0)
-# Fetch nlohmann_json
-FetchContent_Declare(
-    nlohmann_json
-    URL https://github.com/nlohmann/json/releases/download/${NLOHMANN_JSON_VERSION}/json.tar.xz
-    URL_HASH SHA256=42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa  # Verify the hash matches the tarball
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-)
-FetchContent_MakeAvailable(nlohmann_json)
+set(NLOHMANN_JSON_VERSION 3.12.0)
 
-# Disable building tests for json_schema_validator
-set(JSON_VALIDATOR_BUILD_TESTS OFF CACHE BOOL "Do not build tests for json_schema_validator")
-# Fetch json_schema_validator from your fork
-set(nlohmann_json_VERSION ${NLOHMANN_JSON_VERSION})
-FetchContent_Declare(
-    json_schema_validator
-    GIT_REPOSITORY https://github.com/pboettch/json-schema-validator
-    GIT_TAG        40af3ec39670e768fc3f01f935140af311d71024
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-)
-FetchContent_MakeAvailable(json_schema_validator)
+# Handle nlohmann_json: use system version or fetch
+if(USE_SYSTEM_NLOHMANN_JSON)
+    find_package(nlohmann_json ${NLOHMANN_JSON_VERSION} REQUIRED CONFIG)
+    message(STATUS "Using system-installed nlohmann_json")
+else()
+    # Disable building tests for nlohmann_json
+    set(JSON_BuildTests OFF CACHE BOOL "Do not build tests for nlohmann_json")
+    # Fetch nlohmann_json
+    FetchContent_Declare(
+        nlohmann_json
+        URL https://github.com/nlohmann/json/releases/download/v${NLOHMANN_JSON_VERSION}/json.tar.xz
+        URL_HASH SHA256=42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa  # Verify the hash matches the tarball
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(nlohmann_json)
+    message(STATUS "Using fetched nlohmann_json")
+endif()
+
+# Handle json_schema_validator: use system version or fetch
+if(USE_SYSTEM_JSON_SCHEMA_VALIDATOR)
+    find_package(nlohmann_json_schema_validator REQUIRED CONFIG)
+    message(STATUS "Using system-installed nlohmann_json_schema_validator")
+else()
+    # Disable building tests for json_schema_validator
+    set(JSON_VALIDATOR_BUILD_TESTS OFF CACHE BOOL "Do not build tests for json_schema_validator")
+    # Fetch json_schema_validator
+    set(nlohmann_json_VERSION ${NLOHMANN_JSON_VERSION})
+    FetchContent_Declare(
+        json_schema_validator
+        GIT_REPOSITORY https://github.com/pboettch/json-schema-validator
+        GIT_TAG        40af3ec39670e768fc3f01f935140af311d71024
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(json_schema_validator)
+    message(STATUS "Using fetched json_schema_validator")
+endif()
 
 target_link_libraries(mnxdom PUBLIC nlohmann_json::nlohmann_json)
 target_link_libraries(mnxdom PUBLIC nlohmann_json_schema_validator)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(mnxdom LANGUAGES CXX)
 
 include(FetchContent)
 
+option(BUILD_SHARED_LIBS "Build mnxdom as a shared library" OFF)
+
 # Set default build type to Release
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type (Release/Debug)" FORCE)
@@ -35,7 +37,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/cmake/MnxW3C.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/GenerateMnxSchemaXxd.cmake")
 
 # Add library
-add_library(mnxdom STATIC
+add_library(mnxdom
     src/EnumerationMaps.cpp
     src/Implementations.cpp
     src/validation/SchemaValidate.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,3 +91,15 @@ if(mnxdom_BUILD_TESTING)
 else()
     message(STATUS "Testing not enabled for mnxdom_BUILD_TESTING.")
 endif()
+
+# Install rules
+install(TARGETS mnxdom
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+# Install public headers
+install(DIRECTORY src/
+    DESTINATION include/mnxdom
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/cmake/MnxW3C.cmake
+++ b/cmake/MnxW3C.cmake
@@ -1,15 +1,21 @@
 include(FetchContent)
 
-# Fetch MNX spec
-FetchContent_Declare(
-    mnx_w3c
-    GIT_REPOSITORY https://github.com/w3c/mnx.git
-    GIT_TAG 75551875790062bc9d61e3ca468a050136021f58
-    SOURCE_SUBDIR _cmake_disabled_please_ignore # this is a hack to prevent FetchContent_Declare from running the fetched content cmake.
-    # see https://stackoverflow.com/questions/79261625/cmake-fetchcontent-with-header-only-project/79261858#79261858
-)
-FetchContent_MakeAvailable(mnx_w3c)
-message(STATUS "mnx_w3c fetched at: ${mnx_w3c_SOURCE_DIR}")
+# Handle mnx_w3c: use local source directory or fetch
+if(MNX_W3C_SOURCE AND EXISTS "${MNX_W3C_SOURCE}")
+    set(mnx_w3c_SOURCE_DIR "${MNX_W3C_SOURCE}")
+    message(STATUS "Using local mnx_w3c from: ${mnx_w3c_SOURCE_DIR}")
+else()
+    # Fetch MNX spec
+    FetchContent_Declare(
+        mnx_w3c
+        GIT_REPOSITORY https://github.com/w3c/mnx.git
+        GIT_TAG 75551875790062bc9d61e3ca468a050136021f58
+        SOURCE_SUBDIR _cmake_disabled_please_ignore # this is a hack to prevent FetchContent_Declare from running the fetched content cmake.
+        # see https://stackoverflow.com/questions/79261625/cmake-fetchcontent-with-header-only-project/79261858#79261858
+    )
+    FetchContent_MakeAvailable(mnx_w3c)
+    message(STATUS "Using fetched mnx_w3c at: ${mnx_w3c_SOURCE_DIR}")
+endif()
 
 set(MNX_W3C_SCHEMA_PATH "${mnx_w3c_SOURCE_DIR}/docs/mnx-schema.json")
 set(MNX_W3C_EXAMPLES_PATH "${mnx_w3c_SOURCE_DIR}/docs/static/examples/json")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,13 +1,33 @@
 # Add Google Test
 include(FetchContent)
-FetchContent_Declare(
-	googletest
-    URL https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz
-	DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-)
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+
+# Option for using system-installed googletest instead of fetching
+option(USE_SYSTEM_GOOGLETEST "Use system-installed googletest instead of fetching" OFF)
+
+# Define the version of googletest to use
+set(GOOGLETEST_VERSION 1.15.2)
+
+# Handle googletest: use system version or fetch
+if(USE_SYSTEM_GOOGLETEST)
+    find_package(GTest ${GOOGLETEST_VERSION} REQUIRED CONFIG)
+    message(STATUS "Using system-installed googletest")
+    # System GTest uses different target names
+    set(GTEST_MAIN_TARGET GTest::gtest_main)
+    set(GTEST_TARGET GTest::gtest)
+else()
+    # For Windows: Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/releases/download/v${GOOGLETEST_VERSION}/googletest-${GOOGLETEST_VERSION}.tar.gz
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(googletest)
+    message(STATUS "Using fetched googletest")
+    # FetchContent GTest uses these target names
+    set(GTEST_MAIN_TARGET gtest_main)
+    set(GTEST_TARGET gtest)
+endif()
 
 # Add test executable
 add_executable(mnxdom_tests
@@ -38,7 +58,7 @@ endif()
 target_include_directories(mnxdom_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(mnxdom_tests PRIVATE
-    gtest_main
+    ${GTEST_MAIN_TARGET}
     mnxdom
 )
 


### PR DESCRIPTION
Hello,

I'm the maintainer of [Musescore](https://github.com/musescore/MuseScore) in [Nixpkgs](https://github.com/NixOS/nixpkgs) - the package collection of [NixOS](https://nixos.org/). Nix is a package manager that treats package recipes like pure functions, and package inputs that are not explicitly declared, cannot be used. This means that `FetchContent` CMake functions fail in our build environment. This is relevant to this package because Musescore is using this with your package here:

https://github.com/musescore/MuseScore/blob/c106c4fe18efeb32bdb9c46a6475ba530f769fe6/src/importexport/mnx/CMakeLists.txt#L12-L16

So in order to package successfully the next version of Musescore I have to make Musescore be able to use an mnxdom system installation. This made me realize that this `FetchContent` pattern is used here too, and that two more changes are required for the next Musescore version :). Commits are:

- **Add an install target**
- **Allow building a shared object**
- **Allow building offline**
