### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/Implementations.cpp
+++ b/src/Implementations.cpp
@@ -549,7 +549,7 @@ BarlineType global::Measure::calcBarlineType() const
 
 int global::Measure::calcVisibleNumber() const
 {
-    return number_or(calcArrayIndex() + 1);
+    return number_or(static_cast<int>(calcArrayIndex()) + 1);
 }
 
 std::optional<TimeSignature> global::Measure::calcCurrentTime() const


### PR DESCRIPTION
reg.: 'argument': conversion from 'size_t' to 'const int', possible loss of data (C4267)