### PR TITLE
Add pointing to fermata (still MNX schema 15.)

### DIFF
--- a/src/CommonClasses.h
+++ b/src/CommonClasses.h
@@ -41,9 +41,10 @@ class Fermata : public Object
 public:
     using Object::Object;
 
-    MNX_OPTIONAL_PROPERTY_WITH_DEFAULT(FermataDuration, duration, FermataDuration::Auto);   ///< subjective playback duration of the fermata
-    MNX_OPTIONAL_PROPERTY_WITH_DEFAULT(Orientation, orient, Orientation::Auto);             ///< vertical visual orientation of the fermata symbol
-    MNX_OPTIONAL_PROPERTY_WITH_DEFAULT(FermataSymbol, symbol, FermataSymbol::Normal);       ///< the style of symbol for the fermata
+    MNX_OPTIONAL_PROPERTY_WITH_DEFAULT(FermataDuration, duration, FermataDuration::Auto);       ///< subjective playback duration of the fermata
+    MNX_OPTIONAL_PROPERTY_WITH_DEFAULT(Orientation, orient, Orientation::Auto);                 ///< vertical placement of the fermata
+    MNX_OPTIONAL_PROPERTY_WITH_DEFAULT(MarkingUpDownAuto, pointing, MarkingUpDownAuto::Auto);   ///< direction of the fermata symbol
+    MNX_OPTIONAL_PROPERTY_WITH_DEFAULT(FermataSymbol, symbol, FermataSymbol::Normal);           ///< the style of symbol for the fermata
 };
 
 /**

--- a/src/EventMarkings.h
+++ b/src/EventMarkings.h
@@ -165,7 +165,8 @@ class StrongAccent : public EventMarkingBase
 public:
     using EventMarkingBase::EventMarkingBase;
 
-    MNX_OPTIONAL_PROPERTY_WITH_DEFAULT(MarkingUpDownAuto, pointing, MarkingUpDownAuto::Auto);   ///< Specifies if the accent points upward or downward.
+    MNX_OPTIONAL_PROPERTY_WITH_DEFAULT(MarkingUpDownAuto, pointing, MarkingUpDownAuto::Auto);   ///< Specifies if the accent points upward or downward,
+                                                                                                ///< irrespective of above/below orientation.
 };
 
 /**


### PR DESCRIPTION
Add `pointing` field to `Fermata` class. This was omitted in the previous PR for MNX schema 15.