### PR TITLE
Provisional formatted text

### DIFF
--- a/src/BaseTypes.h
+++ b/src/BaseTypes.h
@@ -813,8 +813,11 @@ private:
     template <typename T, typename... Args>
     T appendWithType(Args&&... args)
     {
+        static_assert(std::is_base_of_v<ContentObject, T>,
+                      "ContentArray::appendWithType requires a ContentObject-derived type.");
         auto result = BaseArray::append<T>(std::forward<Args>(args)...);
-        if (T::ContentTypeValue != result.defaultType()) {
+        const ContentObject& contentObject = result;
+        if (T::ContentTypeValue != contentObject.defaultType()) {
             result.set_type(std::string(T::ContentTypeValue));
         }
         return result;

--- a/src/BaseTypes.h
+++ b/src/BaseTypes.h
@@ -415,7 +415,7 @@ class Object : public Base
 {
 public:
     /// @brief Constructor fresh document or detached instance
-    Object() : Base(std::make_shared<json>(json::object()), json_pointer{})
+    Object() : Object(std::make_shared<json>(json::object()), json_pointer{})
     {}
         
     /// @brief Wraps an Object class around an existing JSON object node
@@ -534,6 +534,10 @@ public:
 
     using iterator = iter<Array>;               ///< non-const iterator type
     using const_iterator = iter<const Array>;   ///< const iterator type
+
+    /// @brief Constructor for detached array instance
+    Array() : Array(std::make_shared<json>(json::array()), json_pointer{})
+    {}
 
     /// @brief Wraps an Array class around an existing JSON array node
     /// @param root Reference to the document root
@@ -691,12 +695,12 @@ class ContentArray;
 class ContentObject : public ArrayElementObject
 {
 protected:
-    static constexpr std::string_view ContentTypeValueDefault = "event"; ///< default type value that identifies the type within the content array
+    virtual std::string_view defaultType() const;
 
 public:
     using ArrayElementObject::ArrayElementObject;
 
-    MNX_OPTIONAL_PROPERTY_WITH_DEFAULT(std::string, type, std::string(ContentTypeValueDefault));   ///< determines our type in the JSON
+    MNX_OPTIONAL_PROPERTY_WITH_DEFAULT(std::string, type, std::string(defaultType()));   ///< determines our type in the JSON
 
     /// @brief Retrieve an element as a specific type
     template <typename T, std::enable_if_t<std::is_base_of_v<ContentObject, T>, int> = 0>
@@ -810,7 +814,7 @@ private:
     T appendWithType(Args&&... args)
     {
         auto result = BaseArray::append<T>(std::forward<Args>(args)...);
-        if constexpr (T::ContentTypeValue != ContentObject::ContentTypeValueDefault) {
+        if (T::ContentTypeValue != result.defaultType()) {
             result.set_type(std::string(T::ContentTypeValue));
         }
         return result;

--- a/src/ContentArrayAppendOverloads.h
+++ b/src/ContentArrayAppendOverloads.h
@@ -58,6 +58,18 @@ inline sequence::Tuplet ContentArray::append<sequence::Tuplet, NoteValueQuantity
     return appendWithType<sequence::Tuplet>(innerNoteValueQuant, outerNoteValueQuant);
 }
 
+template <>
+inline text::Text ContentArray::append<text::Text, std::string>(const std::string& text)
+{
+    return appendWithType<text::Text>(text);
+}
+
+template <>
+inline text::Smufl ContentArray::append<text::Smufl, std::vector<std::string>>(const std::vector<std::string>& glyphs)
+{
+    return appendWithType<text::Smufl>(glyphs);
+}
+
 } // namespace mnx
 
 #endif // DOXYGEN_SHOULD_IGNORE_THIS

--- a/src/EnumerationMaps.cpp
+++ b/src/EnumerationMaps.cpp
@@ -102,6 +102,16 @@ MNX_ENUM_MAPPING(FermataSymbol, {
     { "square",         FermataSymbol::Square }
 });
 
+MNX_ENUM_MAPPING(FontStyle, {
+    { "plain",          FontStyle::Plain },
+    { "italic",         FontStyle::Italic }
+});
+
+MNX_ENUM_MAPPING(FontWeight, {
+    { "plain",          FontWeight::Plain },
+    { "bold",           FontWeight::Bold }
+});
+
 MNX_ENUM_MAPPING(GraceType, {
     { "makeTime",       GraceType::MakeTime },
     { "stealFollowing", GraceType::StealFollowing },

--- a/src/Enumerations.h
+++ b/src/Enumerations.h
@@ -129,6 +129,26 @@ enum class FermataSymbol
 };
 
 /**
+ * @enum FontStyle
+ * @brief Specifies the style of text glyphs.
+ */
+enum class FontStyle
+{
+    Plain,          ///< plain (non-italic) text
+    Italic          ///< italic text
+};
+
+/**
+ * @enum FontWeight
+ * @brief Specifies the weight of text glyphs.
+ */
+enum class FontWeight
+{
+    Plain,          ///< plain (non-bold) text
+    Bold            ///< bold text
+};
+
+/**
  * @enum GraceType
  * @brief Options for how to perform grace notes.
  */

--- a/src/FormattedText.h
+++ b/src/FormattedText.h
@@ -57,7 +57,9 @@ public:
     using Object::Object;
 
     MNX_OPTIONAL_PROPERTY(std::string, font);       ///< the name of the font
+    MNX_OPTIONAL_PROPERTY_WITH_DEFAULT(FontStyle, fontStyle, FontStyle::Plain);  ///< the font style
     MNX_OPTIONAL_PROPERTY(double, size);            ///< the font size
+    MNX_OPTIONAL_PROPERTY_WITH_DEFAULT(FontWeight, weight, FontWeight::Plain);  ///< the font weight
 };
 
 /**

--- a/src/FormattedText.h
+++ b/src/FormattedText.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2025, Robert Patterson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#pragma once
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "BaseTypes.h"
+
+namespace mnx {
+
+/**
+ * @namespace mnx::text
+ * @brief classes related to formatted text objects
+ */
+namespace text {
+
+/**
+ * @class TextContentObject
+ * @brief Base class for formatted-text content objects.
+ */
+class TextContentObject : public ContentObject
+{
+protected:
+    std::string_view defaultType() const override { return "text"; }
+
+public:
+    using ContentObject::ContentObject;
+};
+
+/**
+ * @class Style
+ * @brief Describes styling for formatted text content.
+ */
+class Style : public Object
+{
+public:
+    using Object::Object;
+
+    MNX_OPTIONAL_PROPERTY(std::string, font);       ///< the name of the font
+    MNX_OPTIONAL_PROPERTY(double, size);            ///< the font size
+};
+
+/**
+ * @class Text
+ * @brief Represents a formatted text fragment.
+ */
+class Text : public TextContentObject
+{
+public:
+    /// @brief initializer class for #Text
+    struct Required
+    {
+        std::string text;   ///< the text to be represented
+    };
+
+    /// @brief Constructor for existing Text objects
+    Text(const std::shared_ptr<json>& root, json_pointer pointer)
+        : TextContentObject(root, pointer)
+    {
+    }
+
+    /// @brief Creates a new Text class as a child of a JSON element.
+    /// @param parent The parent class instance.
+    /// @param key The JSON key to use for embedding in parent.
+    /// @param text The text to be represented.
+    Text(Base& parent, std::string_view key, const std::string& text)
+        : TextContentObject(parent, key)
+    {
+        set_text(text);
+    }
+
+    /// @brief Implicit conversion back to Required.
+    operator Required() const { return { text() }; }
+
+    /// @brief Create a Required instance for #Text.
+    static Required make(const std::string& text) { return { text }; }
+
+    MNX_REQUIRED_PROPERTY(std::string, text);       ///< the text for this formatted chunk
+    MNX_OPTIONAL_CHILD(Style, style);               ///< the style for this formatted chunk
+
+    inline static constexpr std::string_view ContentTypeValue = "text";    ///< type value that identifies the type within the content array
+};
+
+/**
+ * @class Smufl
+ * @brief Represents a formatted text fragment expressed as SMuFL glyphs.
+ */
+class Smufl : public TextContentObject
+{
+public:
+    /// @brief initializer class for #Smufl
+    struct Required
+    {
+        std::vector<std::string> glyphs;   ///< the smufl glyphs in this chunk
+    };
+
+    /// @brief Constructor for existing Smufl objects
+    Smufl(const std::shared_ptr<json>& root, json_pointer pointer)
+        : TextContentObject(root, pointer)
+    {
+    }
+
+    /// @brief Creates a new Smufl class as a child of a JSON element.
+    /// @param parent The parent class instance.
+    /// @param key The JSON key to use for embedding in parent.
+    /// @param glyphs The smufl glyphs in this chunk.
+    Smufl(Base& parent, std::string_view key, const std::vector<std::string>& glyphs)
+        : TextContentObject(parent, key)
+    {
+        auto glyphArray = create_glyphs();
+        for (const auto& glyph : glyphs) {
+            glyphArray.push_back(glyph);
+        }
+    }
+
+    /// @brief Implicit conversion back to Required.
+    operator Required() const { return { glyphs().toStdVector() }; }
+
+    /// @brief Create a Required instance for #Smufl.
+    static Required make(const std::vector<std::string>& glyphs) { return { glyphs }; }
+
+    using TextContentObject::TextContentObject;
+
+    MNX_REQUIRED_CHILD(Array<std::string>, glyphs);     ///< the smufl glyphs in this chunk
+    MNX_OPTIONAL_CHILD(Style, style);                   ///< the style for the glyphs in thie chunk
+
+    inline static constexpr std::string_view ContentTypeValue = "smufl";    ///< type value that identifies the type within the content array
+};
+
+} // namespace text
+
+/**
+ * @class FormattedText
+ * @brief Container for formatted-text content objects.
+ */
+class FormattedText : public ContentArray
+{
+public:
+    using ContentArray::ContentArray;
+};
+
+} // namespace mnx

--- a/src/Implementations.cpp
+++ b/src/Implementations.cpp
@@ -122,6 +122,15 @@ Document Base::document() const
     return Document(root());
 }
 
+// *************************
+// ***** ContentObject *****
+// *************************
+
+std::string_view ContentObject::defaultType() const
+{
+    return sequence::Event::ContentTypeValue;
+}
+
 // ********************
 // ***** Document *****
 // ********************

--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -481,8 +481,8 @@ public:
     /// @brief Calculates and returns the start time of this event within the measure.
     [[nodiscard]] FractionValue calcStartTime() const;
 
-    inline static constexpr std::string_view ContentTypeValue = ContentObject::ContentTypeValueDefault; ///< type value that identifies the type within the content array
-    inline static constexpr std::string_view JsonSchemaTypeName = "event";     ///< required for mapping
+    inline static constexpr std::string_view ContentTypeValue = "event";    ///< type value that identifies the type within the content array
+    inline static constexpr std::string_view JsonSchemaTypeName = "event";  ///< required for mapping
 };
 
 /**

--- a/src/mnxdom.h
+++ b/src/mnxdom.h
@@ -62,6 +62,7 @@
 #include "Enumerations.h"
 #include "Global.h"
 #include "Layout.h"
+#include "FormattedText.h"
 #include "Part.h"
 #include "Score.h"
 #include "Document.h"

--- a/src/validation/SemanticValidate.cpp
+++ b/src/validation/SemanticValidate.cpp
@@ -181,11 +181,8 @@ std::optional<ArpeggioSpanEndpoints> SemanticValidator::resolveArpeggioSpanEndpo
 
 std::optional<ArpeggioSpanEndpoints> SemanticValidator::validateArpeggioBase(const mnx::part::Measure& measure, const part::ArpeggioBase& arpeggioBase, std::string_view objectName)
 {
-    if (arpeggioBase.span().start() == arpeggioBase.span().end()) {
-        addError(std::string(objectName) + " span start and end must reference different notes.", arpeggioBase);
-        return std::nullopt;
-    }
-
+    // start and end notes may be equal.
+    
     auto endpoints = resolveArpeggioSpanEndpoints(arpeggioBase);
     if (!endpoints) {
         return std::nullopt;


### PR DESCRIPTION
Adds formatted text classes based on proposed spec. This implementation will change if/when formatted text is added to the spec officially. Meanwhile, it is a standalone feature that is not hooked up to any other classes.